### PR TITLE
handle piped input to stdin

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -174,6 +175,9 @@ func getPassphrase(repeat bool) (string, error) {
 			return "", errors.New("Passphrases do not match")
 		}
 	}
+
+	passphrase = strings.TrimRight(passphrase, "\n")
+
 	return passphrase, err
 }
 


### PR DESCRIPTION
My goal was to use the sym-decrypt command for non-interactive decryption, piping the symmetric key into the command.

The trouble I had was if I did e.g.
`printf "asdf" | ./gobox sym-decrypt /tmp/foo.enc /tmp/foo.clear`
Then the ReadString would fail because there wasn't a newline in the passphrase.

But I did e.g.:
`echo "asdf" | ./gobox sym-decrypt /tmp/foo.enc /tmp/foo.clear`
Then the ReadString would result in "asdf\n" as the passphrase, so would fail decrypting.

This change allows the use of echo piping into the command, then strips the newline after parsing it.     So works for me.  I was a little confused by its necessity though, since it looks like you already coded to handle that situation.  Is this style of usage already working for you using some existing command?  Thanks.